### PR TITLE
modify constraints example to work with OpenShift starter account

### DIFF
--- a/specs/pods/oc-constraint-pod.yaml
+++ b/specs/pods/oc-constraint-pod.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: constraintpod
+spec:
+  containers:
+  - name: sise
+    image: mhausenblas/simpleservice:0.5.0
+    ports:
+    - containerPort: 9876
+    resources:
+      limits:
+        cpu: "30m"
+        memory: "250Mi" 


### PR DESCRIPTION
The included example for constraints doesn't work with the OpenShift starter account, so I created a new file called oc-constraint-pod.yaml that does work.  Feel free to trash this if it's not relevant. 