### PR TITLE
updates logging

### DIFF
--- a/content/page/logging.md
+++ b/content/page/logging.md
@@ -52,7 +52,7 @@ you can print the logs for previous instances of the container in a pod:
 
 ```bash
 $ kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/master/specs/logging/oneshotpod.yaml
-$ kubectl logs -p oneshot -c gen
+$ kubectl logs -p oneshot
 9
 8
 7


### PR DESCRIPTION
Remove container argument since it should be terminated and it otherwise causes an error.