### PR TITLE
specs: deployments: d09: update apiVersion to apps/v1

### DIFF
--- a/specs/deployments/d09.yaml
+++ b/specs/deployments/d09.yaml
@@ -1,9 +1,12 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sise-deploy
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      app: sise
   template:
     metadata:
       labels:


### PR DESCRIPTION
This PR was created to mitigate the Deployment error shown below when used with minikube

```
error: unable to recognize "https://raw.githubusercontent.com/openshift-evangelists/kbe/master/specs/deployments/d09.yaml":  no matches for kind "Deployment" in version "apps/v1beta1"
```

Versions
```
Minikube
--------
minikube version: v1.5.2
commit: 792dbf92a1de583fcee76f8791cff12e0c9440ad

Kubernetes and kubectl
------------------------
Client Version: version.Info{Major:"1", Minor:"16", GitVersion:"v1.16.3", GitCommit:"b3cbbae08ec52a7fc73d334838e18d17e8512749", GitTreeState:"clean", BuildDate:"2019-11-14T04:24:29Z", GoVersion:"go1.12.13", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"16", GitVersion:"v1.16.2", GitCommit:"c97fe5036ef3df2967d086711e6c0c405941e14b", GitTreeState:"clean", BuildDate:"2019-10-15T19:09:08Z", GoVersion:"go1.12.10", Compiler:"gc", Platform:"linux/amd64"}
```