### PR TITLE
specs: deployments: d10: update apiVersion to apps/v1

### DIFF
--- a/specs/deployments/d10.yaml
+++ b/specs/deployments/d10.yaml
@@ -1,9 +1,12 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sise-deploy
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      app: sise
   template:
     metadata:
       labels:


### PR DESCRIPTION
This PR was created to mitigate the Deployment error shown below when used with minikube

```
error: unable to recognize "https://raw.githubusercontent.com/openshift-evangelists/kbe/master/specs/deployments/d10.yaml": no matches for kind "Deployment" in version "apps/v1beta1"
```

Versions
```
Minikube
--------
minikube version: v1.6.2
commit: 54f28ac5d3a815d1196cd5d57d707439ee4bb392

Kubernetes and kubectl
------------------------
Client Version: version.Info{Major:"1", Minor:"17", GitVersion:"v1.17.0", GitCommit:"70132b0f130acc0bed193d9ba59dd186f0e634cf", GitTreeState:"clean", BuildDate:"2019-12-13T11:52:32Z", GoVersion:"go1.13.4", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"16", GitVersion:"v1.16.2", GitCommit:"c97fe5036ef3df2967d086711e6c0c405941e14b", GitTreeState:"clean", BuildDate:"2019-10-15T19:09:08Z", GoVersion:"go1.12.10", Compiler:"gc", Platform:"linux/amd64"}
```