### PR TITLE
specs: update to apps/v1 to fix v1.16 compatibility 

### DIFF
--- a/specs/deployments/d09.yaml
+++ b/specs/deployments/d09.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sise-deploy

--- a/specs/deployments/d09.yaml
+++ b/specs/deployments/d09.yaml
@@ -4,6 +4,9 @@ metadata:
   name: sise-deploy
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      app: sise
   template:
     metadata:
       labels:

--- a/specs/deployments/d10.yaml
+++ b/specs/deployments/d10.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sise-deploy

--- a/specs/deployments/d10.yaml
+++ b/specs/deployments/d10.yaml
@@ -4,6 +4,9 @@ metadata:
   name: sise-deploy
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      app: sise
   template:
     metadata:
       labels:

--- a/specs/ic/deploy.yaml
+++ b/specs/ic/deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ic-deploy

--- a/specs/ic/deploy.yaml
+++ b/specs/ic/deploy.yaml
@@ -4,6 +4,9 @@ metadata:
   name: ic-deploy
 spec:
   replicas: 1
+  elector:
+    matchLabels:
+      app: ic
   template:
     metadata:
       labels:

--- a/specs/pf/app.yaml
+++ b/specs/pf/app.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sise-deploy

--- a/specs/pf/app.yaml
+++ b/specs/pf/app.yaml
@@ -4,6 +4,9 @@ metadata:
   name: sise-deploy
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: sise
   template:
     metadata:
       labels:

--- a/specs/pv/deploy.yaml
+++ b/specs/pv/deploy.yaml
@@ -4,6 +4,9 @@ metadata:
   name: pv-deploy
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: mypv
   template:
     metadata:
       labels:

--- a/specs/pv/deploy.yaml
+++ b/specs/pv/deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pv-deploy


### PR DESCRIPTION
I was trying to play with examples at [1] and found out
they are no longer working with v1.16:

> $ kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/master/specs/deployments/d10.yaml
error: unable to recognize "https://raw.githubusercontent.com/openshift-evangelists/kbe/master/specs/deployments/d10.yaml": no matches for kind "Deployment" in version "apps/v1beta1"

The reason is, per [2]:

> The v1.16 release will stop serving the following deprecated
> API versions in favor of newer and more stable API versions:
> ...
> DaemonSet, Deployment, StatefulSet, and ReplicaSet (in the
> extensions/v1beta1 and apps/v1beta2 API groups

As per recommendation in [2], let's switch to `apps/v1`, available
since v1.9.

The first commit was generated by

> for f in $(git grep -W -l apps/v1beta1); do
>  sed -i 's|: apps/v1beta1|: apps/v1|' $f;
> done

Once fixed, the second issue showed up:

> error: error validating "https://raw.githubusercontent.com/kolyshkin/kbe/v1.16-fixes/specs/deployments/d09.yaml": error validating data: ValidationError(Deployment.spec): missing required field "selector" in io.k8s.api.apps.v1.DeploymentSpec; if you choose to ignore these errors, turn validation off with --validate=false

The fix was to add `selector:` (see second commit) as per documentation at [3]

[1] http://kubernetesbyexample.com/deployments/
[2] https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/
[3] https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#creating-a-deployment