### PR TITLE
Style updates for example code and output (#56,#57)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ for the content in Markdown and [specs/](specs/) for respective YAML specificati
 1. Get your local preview by running following command in the top-level dir:
 
 ```bash
-$ hugo server --theme=beautifulhugo --buildDrafts
+hugo server --theme=beautifulhugo --buildDrafts
 ```
 
 ## Publish
@@ -36,12 +36,12 @@ To update the live site with new content:
 
 ```bash
 # still in top-level dir build the content in public/ dir:
-$ hugo --theme=beautifulhugo
+hugo --theme=beautifulhugo
 # add generated content (which lives in the gh-pages branch):
-$ cd public/
-$ git add --all
-$ git commit -m "release notes"
-$ git push -f origin gh-pages
+cd public/
+git add --all
+git commit -m "release notes go here..."
+git push -f origin gh-pages
 ```
 
 ## References

--- a/content/page/deployments.md
+++ b/content/page/deployments.md
@@ -47,20 +47,13 @@ sise-deploy-3513442901-sn74v   1/1       Running   0          25s
 Note the naming of the pods and replica set, derived from the deployment name.
 
 At this point in time the `sise` containers running in the pods are configured
-to return the version `0.9`. Let's verify that from within the cluster (using `kubectl describe`
-first to get the IP of one of the pods):
+to return the version `0.9`. Let's verify that from within the cluster (using `kubectl exec`:
 
 ```bash
-minikube ssh # or `oc rsh`
-```
-```bash
-curl 172.17.0.3:9876/info
+kubectl exec sise-deploy-3513442901-sn74v -t -- curl -s 127.0.0.1:9876/info
 ```
 ```cat
-{"host": "172.17.0.3:9876", "version": "0.9", "from": "172.17.0.1"}
-```
-```bash
-exit
+{"host": "127.0.0.1:9876", "version": "0.9", "from": "127.0.0.1"}
 ```
 
 Let's now see what happens if we change that version to `1.0` in an updated
@@ -77,8 +70,7 @@ deployment "sise-deploy" configured
 Note that you could have used `kubectl edit deploy/sise-deploy` alternatively to
 achieve the same by manually editing the deployment.
 
-What we now see is the rollout of two new pods with the updated version `1.0` as well
-as the two old pods with version `0.9` being terminated:
+What we now see is the rollout of two new pods with the updated version `1.0` as well as the two old pods with version `0.9` being terminated:
 
 ```bash
 kubectl get pods
@@ -107,16 +99,10 @@ Note that during the deployment you can check the progress using `kubectl rollou
 To verify that if the new `1.0` version is really available, we execute from within the cluster (again using `kubectl describe` get the IP of one of the pods):
 
 ```bash
-minikube ssh #or `oc rsh`
-```
-```bash
-curl 172.17.0.5:9876/info
+kubectl exec sise-deploy-2958877261-nfv28 -t -- curl -s 127.0.0.1:9876/info
 ```
 ```cat
-{"host": "172.17.0.5:9876", "version": "1.0", "from": "172.17.0.1"}
-```
-```bash
-exit
+{"host": "127.0.0.1:9876", "version": "1.0", "from": "127.0.0.1"}
 ```
 
 A history of all deployments is available via:

--- a/content/page/deployments.md
+++ b/content/page/deployments.md
@@ -11,21 +11,34 @@ Let's create a [deployment](https://github.com/openshift-evangelists/kbe/blob/ma
 called `sise-deploy` that supervises two replicas of a pod as well as a replica set:
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/deployments/d09.yaml
+kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/deployments/d09.yaml
 ```
 
 You can have a look at the deployment, as well as the the replica set and the pods the deployment looks after like so:
 
 ```bash
-$ kubectl get deploy
+kubectl get deploy
+```
+
+```cat
 NAME          DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
 sise-deploy   2         2         2            2           10s
+```
 
-$ kubectl get rs
+```bash
+kubectl get rs
+```
+
+```cat
 NAME                     DESIRED   CURRENT   READY     AGE
 sise-deploy-3513442901   2         2         2         19s
+```
 
-$ kubectl get pods
+```bash
+kubectl get pods
+```
+
+```cat
 NAME                           READY     STATUS    RESTARTS   AGE
 sise-deploy-3513442901-cndsx   1/1       Running   0          25s
 sise-deploy-3513442901-sn74v   1/1       Running   0          25s
@@ -38,15 +51,26 @@ to return the version `0.9`. Let's verify that from within the cluster (using `k
 first to get the IP of one of the pods):
 
 ```bash
-[cluster] $ curl 172.17.0.3:9876/info
+minikube ssh # or `oc rsh`
+```
+```bash
+curl 172.17.0.3:9876/info
+```
+```cat
 {"host": "172.17.0.3:9876", "version": "0.9", "from": "172.17.0.1"}
+```
+```bash
+exit
 ```
 
 Let's now see what happens if we change that version to `1.0` in an updated
 [deployment](https://github.com/openshift-evangelists/kbe/blob/main/specs/deployments/d10.yaml):
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/deployments/d10.yaml
+kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/deployments/d10.yaml
+```
+
+```cat
 deployment "sise-deploy" configured
 ```
 
@@ -57,7 +81,9 @@ What we now see is the rollout of two new pods with the updated version `1.0` as
 as the two old pods with version `0.9` being terminated:
 
 ```bash
-$ kubectl get pods
+kubectl get pods
+```
+```cat
 NAME                           READY     STATUS        RESTARTS   AGE
 sise-deploy-2958877261-nfv28   1/1       Running       0          25s
 sise-deploy-2958877261-w024b   1/1       Running       0          25s
@@ -68,7 +94,9 @@ sise-deploy-3513442901-sn74v   1/1       Terminating   0          16m
 Also, a new replica set has been created by the deployment:
 
 ```bash
-$ kubectl get rs
+kubectl get rs
+```
+```cat
 NAME                     DESIRED   CURRENT   READY     AGE
 sise-deploy-2958877261   2         2         2         4s
 sise-deploy-3513442901   0         0         0         24m
@@ -76,39 +104,54 @@ sise-deploy-3513442901   0         0         0         24m
 
 Note that during the deployment you can check the progress using `kubectl rollout status deploy/sise-deploy`.
 
-To verify that if the new `1.0` version is really available, we execute from
-within the cluster (again using `kubectl describe` get the IP of one of the pods):
+To verify that if the new `1.0` version is really available, we execute from within the cluster (again using `kubectl describe` get the IP of one of the pods):
 
 ```bash
-[cluster] $ curl 172.17.0.5:9876/info
+minikube ssh #or `oc rsh`
+```
+```bash
+curl 172.17.0.5:9876/info
+```
+```cat
 {"host": "172.17.0.5:9876", "version": "1.0", "from": "172.17.0.1"}
+```
+```bash
+exit
 ```
 
 A history of all deployments is available via:
 
 ```bash
-$ kubectl rollout history deploy/sise-deploy
+kubectl rollout history deploy/sise-deploy
+```
+```cat
 deployments "sise-deploy"
 REVISION        CHANGE-CAUSE
 1               <none>
 2               <none>
 ```
 
-If there are problems in the deployment Kubernetes will automatically roll back to
-the previous version, however you can also explicitly roll back to a specific revision,
-as in our case to revision 1 (the original pod version):
+If there are problems in the deployment Kubernetes will automatically roll back to the previous version, however you can also explicitly roll back to a specific revision, as in our case to revision 1 (the original pod version):
 
 ```bash
-$ kubectl rollout undo deploy/sise-deploy --to-revision=1
+kubectl rollout undo deploy/sise-deploy --to-revision=1
+```
+```cat
 deployment "sise-deploy" rolled back
-
-$ kubectl rollout history deploy/sise-deploy
+```
+```bash
+kubectl rollout history deploy/sise-deploy
+```
+```cat
 deployments "sise-deploy"
 REVISION        CHANGE-CAUSE
 2               <none>
 3               <none>
-
-$ kubectl get pods
+```
+```bash
+kubectl get pods
+```
+```cat
 NAME                           READY     STATUS    RESTARTS   AGE
 sise-deploy-3513442901-ng8fz   1/1       Running   0          1m
 sise-deploy-3513442901-s8q4s   1/1       Running   0          1m
@@ -121,11 +164,12 @@ Finally, to clean up, we remove the deployment and with it the replica sets and
 pods it supervises:
 
 ```bash
-$ kubectl delete deploy sise-deploy
+kubectl delete deploy sise-deploy
+```
+```cat
 deployment "sise-deploy" deleted
 ```
 
-See also the [docs](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)
-for more options on deployments and when they are triggered.
+See also the [docs](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) for more options on deployments and when they are triggered.
 
 [Previous](/labels) | [Next](/services)

--- a/content/page/envs.md
+++ b/content/page/envs.md
@@ -5,17 +5,19 @@ date = "2019-02-27"
 url = "/envs/"
 +++
 
-You can set environment variables for containers running in a pod and in
-addition, Kubernetes exposes certain runtime infos via environment variables
+You can set environment variables for containers running in a pod and in addition, Kubernetes exposes certain runtime infos via environment variables
 automatically.
 
 Let's launch a [pod](https://github.com/openshift-evangelists/kbe/blob/main/specs/envs/pod.yaml)
 that we pass an environment variable `SIMPLE_SERVICE_VERSION` with the value `1.0`:
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/envs/pod.yaml
-
-$ kubectl describe pod envs | grep IP:
+kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/envs/pod.yaml
+```
+```bash
+kubectl describe pod envs | grep IP:
+```
+```cat
 IP:                     172.17.0.3
 ```
 
@@ -23,7 +25,12 @@ Now, let's verify from within the cluster if the application running in the pod
 has picked up the environment variable `SIMPLE_SERVICE_VERSION`:
 
 ```bash
-[cluster] $ curl 172.17.0.3:9876/info
+minikube ssh # or `oc rsh`
+```
+```bash
+curl 172.17.0.3:9876/info
+```
+```cat
 {"host": "172.17.0.3:9876", "version": "1.0", "from": "172.17.0.1"}
 ```
 
@@ -32,17 +39,24 @@ And indeed it has picked up the user-provided environment variable since the def
 You can check what environment variables Kubernetes itself provides automatically
 (from within the cluster, using a dedicated endpoint that the [app](https://github.com/openshift-labs/simpleservice)
 exposes):
-
 ```bash
-[cluster] $ curl 172.17.0.3:9876/env
+curl 172.17.0.3:9876/env
+```
+```cat
 {"version": "1.0", "env": "{'HOSTNAME': 'envs', 'DOCKER_REGISTRY_SERVICE_PORT': '5000', 'KUBERNETES_PORT_443_TCP_ADDR': '172.30.0.1', 'ROUTER_PORT_80_TCP_PROTO': 'tcp', 'KUBERNETES_PORT_53_UDP_PROTO': 'udp', 'ROUTER_SERVICE_HOST': '172.30.246.127', 'ROUTER_PORT_1936_TCP_PROTO': 'tcp', 'KUBERNETES_SERVICE_PORT_DNS': '53', 'DOCKER_REGISTRY_PORT_5000_TCP_PORT': '5000', 'PATH': '/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin', 'ROUTER_SERVICE_PORT_443_TCP': '443', 'KUBERNETES_PORT_53_TCP': 'tcp://172.30.0.1:53', 'KUBERNETES_SERVICE_PORT': '443', 'ROUTER_PORT_80_TCP_ADDR': '172.30.246.127', 'LANG': 'C.UTF-8', 'KUBERNETES_PORT_53_TCP_ADDR': '172.30.0.1', 'PYTHON_VERSION': '2.7.13', 'KUBERNETES_SERVICE_HOST': '172.30.0.1', 'PYTHON_PIP_VERSION': '9.0.1', 'DOCKER_REGISTRY_PORT_5000_TCP_PROTO': 'tcp', 'REFRESHED_AT': '2017-04-24T13:50', 'ROUTER_PORT_1936_TCP': 'tcp://172.30.246.127:1936', 'KUBERNETES_PORT_53_TCP_PROTO': 'tcp', 'KUBERNETES_PORT_53_TCP_PORT': '53', 'HOME': '/root', 'DOCKER_REGISTRY_SERVICE_HOST': '172.30.1.1', 'GPG_KEY': 'C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF', 'ROUTER_SERVICE_PORT_80_TCP': '80', 'ROUTER_PORT_443_TCP_ADDR': '172.30.246.127', 'ROUTER_PORT_1936_TCP_ADDR': '172.30.246.127', 'ROUTER_SERVICE_PORT': '80', 'ROUTER_PORT_443_TCP_PORT': '443', 'KUBERNETES_SERVICE_PORT_DNS_TCP': '53', 'KUBERNETES_PORT_53_UDP_ADDR': '172.30.0.1', 'KUBERNETES_PORT_53_UDP': 'udp://172.30.0.1:53', 'KUBERNETES_PORT': 'tcp://172.30.0.1:443', 'ROUTER_PORT_1936_TCP_PORT': '1936', 'ROUTER_PORT_80_TCP': 'tcp://172.30.246.127:80', 'KUBERNETES_SERVICE_PORT_HTTPS': '443', 'KUBERNETES_PORT_53_UDP_PORT': '53', 'ROUTER_PORT_80_TCP_PORT': '80', 'ROUTER_PORT': 'tcp://172.30.246.127:80', 'ROUTER_PORT_443_TCP': 'tcp://172.30.246.127:443', 'SIMPLE_SERVICE_VERSION': '1.0', 'ROUTER_PORT_443_TCP_PROTO': 'tcp', 'KUBERNETES_PORT_443_TCP': 'tcp://172.30.0.1:443', 'DOCKER_REGISTRY_PORT_5000_TCP': 'tcp://172.30.1.1:5000', 'DOCKER_REGISTRY_PORT': 'tcp://172.30.1.1:5000', 'KUBERNETES_PORT_443_TCP_PORT': '443', 'ROUTER_SERVICE_PORT_1936_TCP': '1936', 'DOCKER_REGISTRY_PORT_5000_TCP_ADDR': '172.30.1.1', 'DOCKER_REGISTRY_SERVICE_PORT_5000_TCP': '5000', 'KUBERNETES_PORT_443_TCP_PROTO': 'tcp'}"}
+```
+Return:
+```bash
+exit
 ```
 
 Alternatively, you can also use `kubectl exec` to connect to the container and list the
 environment variables directly, there:
 
 ```bash
-$ kubectl exec envs -- printenv
+kubectl exec envs -- printenv
+```
+```cat
 PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 HOSTNAME=envs
 SIMPLE_SERVICE_VERSION=1.0
@@ -58,10 +72,9 @@ ROUTER_PORT=tcp://172.30.246.127:80
 You can destroy the created pod with:
 
 ```bash
-$ kubectl delete pod/envs
+kubectl delete pod/envs
 ```
 
-In addition to the above provided environment variables, you can expose more using
-the [downward API](https://kubernetes.io/docs/user-guide/downward-api/).
+In addition to the above provided environment variables, you can expose more using the [downward API](https://kubernetes.io/docs/user-guide/downward-api/).
 
 [Previous](/healthz) | [Next](/ns)

--- a/content/page/envs.md
+++ b/content/page/envs.md
@@ -14,24 +14,15 @@ that we pass an environment variable `SIMPLE_SERVICE_VERSION` with the value `1.
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/envs/pod.yaml
 ```
-```bash
-kubectl describe pod envs | grep IP:
-```
-```cat
-IP:                     172.17.0.3
-```
 
 Now, let's verify from within the cluster if the application running in the pod
 has picked up the environment variable `SIMPLE_SERVICE_VERSION`:
 
 ```bash
-minikube ssh # or `oc rsh`
-```
-```bash
-curl 172.17.0.3:9876/info
+kubectl exec envs -t -- curl -s 127.0.0.1:9876/info
 ```
 ```cat
-{"host": "172.17.0.3:9876", "version": "1.0", "from": "172.17.0.1"}
+{"host": "127.0.0.1:9876", "version": "1.0", "from": "127.0.0.1"}
 ```
 
 And indeed it has picked up the user-provided environment variable since the default response would be `"version": "0.5.0"`.
@@ -40,18 +31,13 @@ You can check what environment variables Kubernetes itself provides automaticall
 (from within the cluster, using a dedicated endpoint that the [app](https://github.com/openshift-labs/simpleservice)
 exposes):
 ```bash
-curl 172.17.0.3:9876/env
+kubectl exec envs -t -- curl -s 127.0.0.1:9876/env
 ```
 ```cat
 {"version": "1.0", "env": "{'HOSTNAME': 'envs', 'DOCKER_REGISTRY_SERVICE_PORT': '5000', 'KUBERNETES_PORT_443_TCP_ADDR': '172.30.0.1', 'ROUTER_PORT_80_TCP_PROTO': 'tcp', 'KUBERNETES_PORT_53_UDP_PROTO': 'udp', 'ROUTER_SERVICE_HOST': '172.30.246.127', 'ROUTER_PORT_1936_TCP_PROTO': 'tcp', 'KUBERNETES_SERVICE_PORT_DNS': '53', 'DOCKER_REGISTRY_PORT_5000_TCP_PORT': '5000', 'PATH': '/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin', 'ROUTER_SERVICE_PORT_443_TCP': '443', 'KUBERNETES_PORT_53_TCP': 'tcp://172.30.0.1:53', 'KUBERNETES_SERVICE_PORT': '443', 'ROUTER_PORT_80_TCP_ADDR': '172.30.246.127', 'LANG': 'C.UTF-8', 'KUBERNETES_PORT_53_TCP_ADDR': '172.30.0.1', 'PYTHON_VERSION': '2.7.13', 'KUBERNETES_SERVICE_HOST': '172.30.0.1', 'PYTHON_PIP_VERSION': '9.0.1', 'DOCKER_REGISTRY_PORT_5000_TCP_PROTO': 'tcp', 'REFRESHED_AT': '2017-04-24T13:50', 'ROUTER_PORT_1936_TCP': 'tcp://172.30.246.127:1936', 'KUBERNETES_PORT_53_TCP_PROTO': 'tcp', 'KUBERNETES_PORT_53_TCP_PORT': '53', 'HOME': '/root', 'DOCKER_REGISTRY_SERVICE_HOST': '172.30.1.1', 'GPG_KEY': 'C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF', 'ROUTER_SERVICE_PORT_80_TCP': '80', 'ROUTER_PORT_443_TCP_ADDR': '172.30.246.127', 'ROUTER_PORT_1936_TCP_ADDR': '172.30.246.127', 'ROUTER_SERVICE_PORT': '80', 'ROUTER_PORT_443_TCP_PORT': '443', 'KUBERNETES_SERVICE_PORT_DNS_TCP': '53', 'KUBERNETES_PORT_53_UDP_ADDR': '172.30.0.1', 'KUBERNETES_PORT_53_UDP': 'udp://172.30.0.1:53', 'KUBERNETES_PORT': 'tcp://172.30.0.1:443', 'ROUTER_PORT_1936_TCP_PORT': '1936', 'ROUTER_PORT_80_TCP': 'tcp://172.30.246.127:80', 'KUBERNETES_SERVICE_PORT_HTTPS': '443', 'KUBERNETES_PORT_53_UDP_PORT': '53', 'ROUTER_PORT_80_TCP_PORT': '80', 'ROUTER_PORT': 'tcp://172.30.246.127:80', 'ROUTER_PORT_443_TCP': 'tcp://172.30.246.127:443', 'SIMPLE_SERVICE_VERSION': '1.0', 'ROUTER_PORT_443_TCP_PROTO': 'tcp', 'KUBERNETES_PORT_443_TCP': 'tcp://172.30.0.1:443', 'DOCKER_REGISTRY_PORT_5000_TCP': 'tcp://172.30.1.1:5000', 'DOCKER_REGISTRY_PORT': 'tcp://172.30.1.1:5000', 'KUBERNETES_PORT_443_TCP_PORT': '443', 'ROUTER_SERVICE_PORT_1936_TCP': '1936', 'DOCKER_REGISTRY_PORT_5000_TCP_ADDR': '172.30.1.1', 'DOCKER_REGISTRY_SERVICE_PORT_5000_TCP': '5000', 'KUBERNETES_PORT_443_TCP_PROTO': 'tcp'}"}
 ```
-Return:
-```bash
-exit
-```
 
-Alternatively, you can also use `kubectl exec` to connect to the container and list the
-environment variables directly, there:
+Alternatively, you can also use `kubectl exec` to connect to the container and list the environment variables directly, there:
 
 ```bash
 kubectl exec envs -- printenv
@@ -69,12 +55,12 @@ ROUTER_PORT=tcp://172.30.246.127:80
 ...
 ```
 
-You can destroy the created pod with:
+Remove the `env` pod with:
 
 ```bash
 kubectl delete pod/envs
 ```
 
-In addition to the above provided environment variables, you can expose more using the [downward API](https://kubernetes.io/docs/user-guide/downward-api/).
+In addition to the above examples, you can also use `secrets`, volumes, or the [downward API](https://kubernetes.io/docs/user-guide/downward-api/) to inject additional information into your container environments.
 
 [Previous](/healthz) | [Next](/ns)

--- a/content/page/healthz.md
+++ b/content/page/healthz.md
@@ -19,12 +19,12 @@ Let's create a [pod](https://github.com/openshift-evangelists/kbe/blob/main/spec
 that exposes an endpoint `/health`, responding with a HTTP `200` status code:
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/healthz/pod.yaml
+kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/healthz/pod.yaml
 ```
 
 In the pod specification we've defined the following:
 
-```
+```cat
 livenessProbe:
   initialDelaySeconds: 2
   periodSeconds: 5
@@ -38,7 +38,9 @@ Above means that Kubernetes will start checking the `/health` endpoint, after in
 If we now look at the pod we can see that it is considered healthy:
 
 ```bash
-$ kubectl describe pod hc
+kubectl describe pod hc
+```
+```cat
 Name:                   hc
 Namespace:              default
 Security Policy:        anyuid
@@ -62,13 +64,15 @@ that is, a pod that has a container that randomly (in the time range 1 to 4 sec)
 does not return a 200 code:
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/healthz/badpod.yaml
+kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/healthz/badpod.yaml
 ```
 
 Looking at the events of the bad pod, we can see that the health check failed:
 
 ```bash
-$ kubectl describe pod badpod
+kubectl describe pod badpod
+```
+```cat
 ...
 Events:
   FirstSeen     LastSeen        Count   From                            SubobjectPath           Type            Reason          Message
@@ -86,7 +90,9 @@ Events:
 This can also be verified as follows:
 
 ```bash
-$ kubectl get pods
+kubectl get pods
+```
+```cat
 NAME                      READY     STATUS    RESTARTS   AGE
 badpod                    1/1       Running   4          2m
 hc                        1/1       Running   0          6m
@@ -106,14 +112,16 @@ Let's create a [pod](https://github.com/openshift-evangelists/kbe/blob/main/spec
 with a `readinessProbe` that kicks in after 10 seconds:
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/healthz/ready.yaml
+kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/healthz/ready.yaml
 ```
 
 Looking at the events of the pod, we can see that, eventually, the pod is ready
 to serve traffic:
 
 ```bash
-$ kubectl describe pod ready
+kubectl describe pod ready
+```
+```cat
 ...
 Conditions:                                                                                                                                                               [0/1888]
   Type          Status
@@ -125,7 +133,7 @@ Conditions:                                                                     
 You can remove all the created pods with:
 
 ```bash
-$ kubectl delete pod/hc pod/ready pod/badpod
+kubectl delete pod/hc pod/ready pod/badpod
 ```
 
 Learn more about configuring probes, including TCP and command probes, via the

--- a/content/page/ic.md
+++ b/content/page/ic.md
@@ -10,25 +10,34 @@ It's sometimes necessary to prepare a container running in a pod. For example, y
 So let's create an [deployment](https://github.com/openshift-evangelists/kbe/blob/main/specs/ic/deploy.yaml) consisting of an init container that writes a message into a file at `/ic/this` and the main (long-running) container reading out this file, then:
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/ic/deploy.yaml
+kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/ic/deploy.yaml
 ```
 
 Now we can check the output of the main container:
 
 ```bash
-$ kubectl get deploy,po
+kubectl get deploy,po
+```
+```cat
 NAME                              DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
 deployment.extensions/ic-deploy   1         1         1            1           11m
 
 NAME                            READY   STATUS    RESTARTS   AGE
 pod/ic-deploy-bf75cbf87-8zmrb   1/1     Running   0          59s
+```
+```bash
+kubectl logs ic-deploy-bf75cbf87-8zmrb -f
+```
+```cat
+INIT_DONE
+INIT_DONE
+INIT_DONE
+INIT_DONE
+INIT_DONE
+```
 
-$ kubectl logs ic-deploy-bf75cbf87-8zmrb -f
-INIT_DONE
-INIT_DONE
-INIT_DONE
-INIT_DONE
-INIT_DONE
+Send a break signal when you're ready to disconnect from the log stream:
+```bash
 ^C
 ```
 

--- a/content/page/jobs.md
+++ b/content/page/jobs.md
@@ -13,17 +13,23 @@ Let's create a [job](https://github.com/openshift-evangelists/kbe/blob/main/spec
 called `countdown` that supervises a pod counting from 9 down to 1:
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/jobs/job.yaml
+kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/jobs/job.yaml
 ```
 
 You can see the job and the pod it looks after like so:
 
 ```bash
-$ kubectl get jobs
+kubectl get jobs
+```
+```cat
 NAME                      DESIRED   SUCCESSFUL   AGE
 countdown                 1         1            5s
+```
 
-$ kubectl get pods
+```bash
+kubectl get pods
+```
+```cat
 NAME              READY   STATUS      RESTARTS   AGE
 countdown-qkjx8   0/1     Completed   0          2m17s
 ```
@@ -31,7 +37,9 @@ countdown-qkjx8   0/1     Completed   0          2m17s
 To learn more about the status of the job, do:
 
 ```bash
-$ kubectl describe jobs/countdown
+kubectl describe jobs/countdown
+```
+```cat
 Name:           countdown
 Namespace:      default
 Selector:       controller-uid=4960c8be-6a3f-11ea-84fd-0242ac11002a
@@ -70,6 +78,8 @@ And to see the output of the job via the pod it supervised, execute:
 
 ```bash
 kubectl logs countdown-qkjx8
+```
+```cat
 9
 8
 7
@@ -85,7 +95,9 @@ To clean up, use the `delete` verb on the job object which will remove all the
 supervised pods:
 
 ```bash
-$ kubectl delete job countdown
+kubectl delete job countdown
+```
+```cat
 job "countdown" deleted
 ```
 

--- a/content/page/labels.md
+++ b/content/page/labels.md
@@ -16,9 +16,12 @@ Let's create a [pod](https://github.com/openshift-evangelists/kbe/blob/main/spec
 
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/labels/pod.yaml
-
-$ kubectl get pods --show-labels
+kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/labels/pod.yaml
+```
+```bash
+kubectl get pods --show-labels
+```
+```cat
 NAME       READY     STATUS    RESTARTS   AGE    LABELS
 labelex    1/1       Running   0          10m    env=development
 ```
@@ -28,9 +31,12 @@ labels of an object in an additional column.
 You can add a label to the pod as:
 
 ```bash
-$ kubectl label pods labelex owner=michael
-
-$ kubectl get pods --show-labels
+kubectl label pods labelex owner=michael
+```
+```bash
+kubectl get pods --show-labels
+```
+```cat
 NAME        READY     STATUS    RESTARTS   AGE    LABELS
 labelex     1/1       Running   0          16m    env=development,owner=michael
 ```
@@ -39,7 +45,9 @@ To use a label for filtering, for example to list only pods that have an
 `owner` that equals `michael`, use the `--selector` option:
 
 ```bash
-$ kubectl get pods --selector owner=michael
+kubectl get pods --selector owner=michael
+```
+```cat
 NAME      READY     STATUS    RESTARTS   AGE
 labelex   1/1       Running   0          27m
 ```
@@ -48,7 +56,9 @@ The `--selector` option can be abbreviated to `-l`, so to select pods that are
 labelled with `env=development`, do:
 
 ```bash
-$ kubectl get pods -l env=development
+kubectl get pods -l env=development
+```
+```cat
 NAME      READY     STATUS    RESTARTS   AGE
 labelex   1/1       Running   0          27m
 ```
@@ -58,14 +68,16 @@ Let's launch [another pod](https://github.com/openshift-evangelists/kbe/blob/mai
 that has two labels (`env=production` and `owner=michael`):
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/labels/anotherpod.yaml
+kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/labels/anotherpod.yaml
 ```
 
 Now, let's list all pods that are either labelled with `env=development` or with
 `env=production`:
 
 ```bash
-$ kubectl get pods -l 'env in (production, development)'
+kubectl get pods -l 'env in (production, development)'
+```
+```cat
 NAME           READY     STATUS    RESTARTS   AGE
 labelex        1/1       Running   0          43m
 labelexother   1/1       Running   0          3m
@@ -75,7 +87,7 @@ Other verbs also support label selection, for example, you could
 remove both of these pods with:
 
 ```bash
-$ kubectl delete pods -l 'env in (production, development)'
+kubectl delete pods -l 'env in (production, development)'
 ```
 
 Beware that this will destroy any pods with those labels.
@@ -83,9 +95,10 @@ Beware that this will destroy any pods with those labels.
 You can also delete them directly, via their names, with:
 
 ```bash
-$ kubectl delete pods labelex
-
-$ kubectl delete pods labelexother
+kubectl delete pods labelex
+```
+```bash
+kubectl delete pods labelexother
 ```
 
 Note that labels are not restricted to pods. In fact you can apply them to

--- a/content/page/logging.md
+++ b/content/page/logging.md
@@ -15,14 +15,16 @@ Let's create a [pod](https://github.com/openshift-evangelists/kbe/blob/main/spec
 called `logme` that runs a container writing to `stdout` and `stderr`:
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/logging/pod.yaml
+kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/logging/pod.yaml
 ```
 
 To view the five most recent log lines of the `gen` container in the `logme` pod,
 execute:
 
 ```bash
-$ kubectl logs --tail=5 logme -c gen
+kubectl logs --tail=5 logme -c gen
+```
+```cat
 Thu Apr 27 11:34:40 UTC 2017
 Thu Apr 27 11:34:41 UTC 2017
 Thu Apr 27 11:34:41 UTC 2017
@@ -33,7 +35,9 @@ Thu Apr 27 11:34:42 UTC 2017
 To stream the log of the `gen` container in the `logme` pod (like `tail -f`), do:
 
 ```bash
-$ kubectl logs -f --since=10s logme -c gen
+kubectl logs -f --since=10s logme -c gen
+```
+```cat
 Thu Apr 27 11:43:11 UTC 2017
 Thu Apr 27 11:43:11 UTC 2017
 Thu Apr 27 11:43:12 UTC 2017
@@ -51,8 +55,12 @@ called `oneshot` that counts down from 9 to 1 and then exits. Using the `-p` opt
 you can print the logs for previous instances of the container in a pod:
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/logging/oneshotpod.yaml
-$ kubectl logs -p oneshot -c gen
+kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/logging/oneshotpod.yaml
+```
+```bash
+kubectl logs -p oneshot -c gen
+```
+```cat
 9
 8
 7
@@ -67,7 +75,7 @@ $ kubectl logs -p oneshot -c gen
 You can remove the created pods with:
 
 ```bash
-$ kubectl delete pod/logme pod/oneshot
+kubectl delete pod/logme pod/oneshot
 ```
 
 [Previous](/secrets) | [Next](/jobs)

--- a/content/page/nodes.md
+++ b/content/page/nodes.md
@@ -12,7 +12,9 @@ To list available nodes in your cluster (note that the output will depend on the
 you're using. This example is using the [OpenShift Playground](/diy/)):
 
 ```bash
-$ kubectl get nodes
+kubectl get nodes
+```
+```cat
 NAME                 STATUS   ROLES           AGE    VERSION
 crc-rk2fc-master-0   Ready    master,worker   102d   v1.14.6+888f9c630
 ```
@@ -22,7 +24,9 @@ schedule a pod on a certain node. For this, we first need to label the node
 we want to target:
 
 ```bash
-$ kubectl label nodes crc-rk2fc-master-0 shouldrun=here
+kubectl label nodes crc-rk2fc-master-0 shouldrun=here
+```
+```cat
 node/crc-rk2fc-master-0 labeled
 ```
 
@@ -30,9 +34,12 @@ Now we can create a [pod](https://github.com/openshift-evangelists/kbe/blob/main
 that gets scheduled on the node with the label `shouldrun=here`:
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/nodes/pod.yaml
-
-$ kubectl get pods --output=wide
+kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/nodes/pod.yaml
+```
+```bash
+kubectl get pods --output=wide
+```
+```cat
 NAME             READY   STATUS    RESTARTS   AGE     IP            NODE            NOMINATED NODE   READINESS GATES
 onspecificnode   1/1     Running   0          2m31s   10.128.1.11   crc-rk2fc-master-0   <none>           <none>
 ```
@@ -40,7 +47,9 @@ onspecificnode   1/1     Running   0          2m31s   10.128.1.11   crc-rk2fc-ma
 To learn more about a specific node, `crc-rk2fc-master-0` in our case, do:
 
 ```bash
-$ kubectl describe node crc-rk2fc-master-0
+kubectl describe node crc-rk2fc-master-0
+```
+```cat
 Name:               crc-rk2fc-master-0
 Roles:              master,worker
 Labels:             beta.kubernetes.io/arch=amd64

--- a/content/page/ns.md
+++ b/content/page/ns.md
@@ -13,7 +13,9 @@ Let's list all namespaces (note that the output will depend on the environment
 you're using, we're using the [OpenShift Playground](/diy/) here):
 
 ```bash
-$ kubectl get ns
+kubectl get ns
+```
+```cat
 NAME                                                    STATUS   AGE
 default                                                 Active   98d
 kube-node-lease                                         Active   98d
@@ -27,7 +29,9 @@ openshift-apiserver                                     Active   98d
 You can learn more about a namespace using the `describe` verb, for example:
 
 ```bash
-$ kubectl describe ns default
+kubectl describe ns default
+```
+```cat
 Name:   default
 Labels: <none>
 Status: Active
@@ -41,10 +45,15 @@ Let's now create a new [namespace](https://github.com/openshift-evangelists/kbe/
 called `test` now:
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/ns/ns.yaml
+kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/ns/ns.yaml
+```
+```cat
 namespace "test" created
-
- kubectl get ns
+```
+```bash
+kubectl get ns
+```
+```cat
 NAME                                                    STATUS   AGE
 default                                                 Active   98d
 kube-node-lease                                         Active   98d
@@ -62,7 +71,7 @@ To launch a [pod](https://github.com/openshift-evangelists/kbe/blob/main/specs/n
 the newly created namespace `test`, do:
 
 ```bash
-$ kubectl apply --namespace=test -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/ns/pod.yaml
+kubectl apply --namespace=test -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/ns/pod.yaml
 ```
 
 Note that using above method the namespace becomes a runtime property, that is,
@@ -70,7 +79,7 @@ you can deploy the same pod or service, etc. into multiple
 namespaces (for example: `dev` and `prod`). Hard-coding the
 namespace directly in the `metadata` section like shown in the following is possible but causes less flexibility when deploying your apps:
 
-```
+```cat
 apiVersion: v1
 kind: Pod
 metadata:
@@ -81,7 +90,9 @@ metadata:
 To list namespaced objects such as our pod `podintest`, run the following command:
 
 ```bash
-$ kubectl get pods --namespace=test
+kubectl get pods --namespace=test
+```
+```cat
 NAME        READY     STATUS    RESTARTS   AGE
 podintest   1/1       Running   0          16s
 ```
@@ -89,7 +100,7 @@ podintest   1/1       Running   0          16s
 You can remove the namespace (and everything inside) with:
 
 ```bash
-$ kubectl delete ns test
+kubectl delete ns test
 ```
 
 If you're an admin, you might want to check out the [docs](https://kubernetes.io/docs/tasks/administer-cluster/namespaces/)

--- a/content/page/pf.md
+++ b/content/page/pf.md
@@ -10,13 +10,15 @@ In the context of developing apps on Kubernetes it is often useful to quickly ac
 Let's create an [app](https://github.com/openshift-evangelists/kbe/blob/main/specs/pf/app.yaml) consisting of a deployment and a service called `simpleservice`, serving on port `80`:
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/pf/app.yaml
+kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/pf/app.yaml
 ```
 
 Let's say we want to access the `simpleservice` service from the local environment, say, your laptop, on port `8080`. So we forward the traffic as follows:
 
 ```bash
-$ kubectl port-forward service/simpleservice 8080:80
+kubectl port-forward service/simpleservice 8080:80
+```
+```cat
 Forwarding from 127.0.0.1:8080 -> 9876
 Forwarding from [::1]:8080 -> 9876
 ```
@@ -26,7 +28,9 @@ We can see from above that the traffic gets eventually routed through the servic
 Now we can invoke the service locally like so (using a separate terminal session):
 
 ```bash
-$ curl localhost:8080/info
+curl localhost:8080/info
+```
+```cat
 {"host": "localhost:8080", "version": "0.5.0", "from": "127.0.0.1"}
 ```
 
@@ -35,8 +39,8 @@ Remember that port forwarding is not meant for production traffic but for develo
 You can remove the `simpleservice` with 
 
 ```bash
-$ kubectl delete service/simpleservice 
-$ kubectl delete deployment sise-deploy
+kubectl delete service/simpleservice 
+kubectl delete deployment sise-deploy
 ```
 
 [Previous](/sd) | [Next](/healthz)

--- a/content/page/pods.md
+++ b/content/page/pods.md
@@ -13,17 +13,24 @@ To launch a pod using the container [image](https://quay.io/repository/openshift
 `quay.io/openshiftlabs/simpleservice:0.5.0` and exposing a HTTP API on port `9876`, execute:
 
 ```bash
-$ kubectl run sise --image=quay.io/openshiftlabs/simpleservice:0.5.0 --port=9876
+kubectl run sise --image=quay.io/openshiftlabs/simpleservice:0.5.0 --port=9876
 ```
 
-We can now see that the pod is running:
+Check to see if the pod is running:
 
 ```bash
-$ kubectl get pods
+kubectl get pods
+```
+```cat
 NAME                      READY     STATUS    RESTARTS   AGE
 sise-3210265840-k705b     1/1       Running   0          1m
+```
 
-$ kubectl describe pod sise-3210265840-k705b | grep IP:
+```bash
+kubectl describe pod sise-3210265840-k705b | grep IP:
+```
+
+```cat
 IP:                     172.17.0.3
 ```
 
@@ -31,8 +38,17 @@ From within the cluster (e.g. via [`oc rsh`](https://docs.openshift.com/containe
 which we've learned from the `kubectl describe` command above:
 
 ```bash
-[cluster] $ curl 172.17.0.3:9876/info
+minikube ssh # or `oc rsh`
+curl 172.17.0.3:9876/info
+```
+
+```cat
 {"host": "172.17.0.3:9876", "version": "0.5.0", "from": "172.17.0.1"}
+```
+
+When you're done inspecting the cluster, `exit` to continue:
+```bash
+exit
 ```
 
 ***Tip: Deprecation Warning!***
@@ -46,9 +62,14 @@ running the already known `simpleservice` image from above along with
 a generic `CentOS` container:
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/pods/pod.yaml
+kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/pods/pod.yaml
+```
 
-$ kubectl get pods
+```bash
+kubectl get pods
+```
+
+```cat
 NAME                      READY     STATUS    RESTARTS   AGE
 twocontainers             2/2       Running   0          7s
 ```
@@ -57,19 +78,29 @@ Now we can exec into the `CentOS` container and access the `simpleservice`
 on localhost:
 
 ```bash
-$ kubectl exec twocontainers -c shell -i -t -- bash
-[root@twocontainers /]# curl -s localhost:9876/info
+kubectl exec twocontainers -c shell -i -t -- bash
+```
+
+```bash
+curl -s localhost:9876/info
+```
+
+```cat
 {"host": "localhost:9876", "version": "0.5.0", "from": "127.0.0.1"}
 ```
 
 Specify the `resources` field in the pod to influence how much CPU and/or RAM a
-container in a [pod](https://github.com/openshift-evangelists/kbe/blob/main/specs/pods/constraint-pod.yaml)
-can use (here: `64MB` of RAM and `0.5` CPUs):
+container in a [pod](https://github.com/openshift-evangelists/kbe/blob/main/specs/pods/constraint-pod.yaml) can use (here: `64MB` of RAM and `0.5` CPUs):
 
 ```bash
-$ kubectl create -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/pods/constraint-pod.yaml
+kubectl create -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/pods/constraint-pod.yaml
+```
 
-$ kubectl describe pod constraintpod
+```bash
+kubectl describe pod constraintpod
+```
+
+```cat
 ...
 Containers:
   sise:
@@ -86,14 +117,12 @@ Containers:
 Learn more about resource constraints in Kubernetes via the docs [here](https://kubernetes.io/docs/tasks/configure-pod-container/assign-cpu-ram-container/)
 and [here](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/).
 
-To remove all the pods created, just run:
+To clean up and remove all the running pods, try:
 
 ```bash
-$ kubectl delete pod,deployment sise
-
-$ kubectl delete pod twocontainers
-
-$ kubectl delete pod constraintpod
+kubectl delete pod,deployment sise
+kubectl delete pod twocontainers
+kubectl delete pod constraintpod
 ```
 
 To sum up, launching one or more containers (together) in Kubernetes is simple,

--- a/content/page/proxy.md
+++ b/content/page/proxy.md
@@ -10,7 +10,9 @@ Sometimes it's useful or necessary to directly [access the Kubernetes API server
 In order to do this, one option is to proxy the API to your local environment, using:
 
 ```bash
-$ kubectl proxy --port=8080
+kubectl proxy --port=8080
+```
+```cat
 Starting to serve on 127.0.0.1:8080
 
 ```
@@ -18,7 +20,9 @@ Starting to serve on 127.0.0.1:8080
 Now you can query the API (in a separate terminal session) like so:
 
 ```bash
-$ curl http://localhost:8080/api/v1
+curl http://localhost:8080/api/v1
+```
+```cat
 {
   "kind": "APIResourceList",
   "groupVersion": "v1",
@@ -43,18 +47,23 @@ $ curl http://localhost:8080/api/v1
 Alternatively, without proxying, you can use `kubectl` directly as follows to achieve the same:
 
 ```bash
-$ kubectl get --raw /api/v1
+kubectl get --raw /api/v1
 ```
 
 Further, if you want to explore the supported API versions and/or resources, you can use the following commands:
 
 ```bash
-$ kubectl api-versions
+kubectl api-versions
+```
+```cat
 admissionregistration.k8s.io/v1beta1
 ...
 v1
-
-$ kubectl api-resources
+```
+```bash
+kubectl api-resources
+```
+```cat
 NAME                                  SHORTNAMES       APIGROUP         NAMESPACED   KIND
 bindings         true         Binding
 componentstatuses                     cs         false        ComponentStatus

--- a/content/page/pv.md
+++ b/content/page/pv.md
@@ -8,18 +8,22 @@ url = "/pv/"
 A [persistent volume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PV) is a cluster-wide resource that you can use to store data in a way that it persists beyond the lifetime of a pod. The PV is not backed by locally-attached storage on a worker node but by networked storage system such as EBS or NFS or a distributed filesystem like Ceph.
 
 If you are using
-[OpenShift Playground](https://learn.openshift.com/playgrounds/openshift42) like us there already exist a few persistent volumes on your cluster.  If not, you'll need to create one first using:
+[OpenShift Playground](https://learn.openshift.com/playgrounds/openshift45) like us there already exist a few persistent volumes on your cluster.  If not, you'll need to create one first using:
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/pv/pv.yaml
+kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/pv/pv.yaml
 ```
 
 In order to use a PV you need to claim it first, using a persistent volume claim (PVC). The PVC requests a PV with your desired specification (size, speed, etc.) from Kubernetes and binds it then to a pod where you can mount it as a volume. So let's create such a [PVC](https://github.com/openshift-evangelists/kbe/blob/main/specs/pv/pvc.yaml), asking Kubernetes for 1 GB of storage using the default [storage class](https://kubernetes.io/docs/concepts/storage/storage-classes/):
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/pv/pvc.yaml
+kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/pv/pvc.yaml
+```
 
-$ kubectl get pvc
+```bash
+kubectl get pvc
+```
+```cat
 NAME      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS    AGE
 myclaim   Bound    pvc-27fed6b6-3047-11e9-84bb-12b5519f9b58   1Gi        RWO            gp2-encrypted   18m
 ```
@@ -27,35 +31,62 @@ myclaim   Bound    pvc-27fed6b6-3047-11e9-84bb-12b5519f9b58   1Gi        RWO    
 To understand how the persistency plays out, let's create a [deployment](https://github.com/openshift-evangelists/kbe/blob/main/specs/pv/deploy.yaml) that uses above PVC to mount it as a volume into `/tmp/persistent`:
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/pv/deploy.yaml
+kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/pv/deploy.yaml
 ```
 
 Now we want to test if data in the volume actually persists. For this we find the pod managed by above deployment, exec into its main container and create a file called `data` in the `/tmp/persistent` directory (where we decided to mount the PV):
 
 ```bash
-$ kubectl get po
+kubectl get po
+```
+```cat
 NAME                         READY   STATUS    RESTARTS   AGE
 pv-deploy-69959dccb5-jhxx    1/1     Running   0          16m
+```
 
-$ kubectl exec -it pv-deploy-69959dccb5-jhxxw -- bash
-bash-4.2$ touch /tmp/persistent/data
-bash-4.2$ ls /tmp/persistent/
+```bash
+kubectl exec -it pv-deploy-69959dccb5-jhxxw -- bash
+```
+```bash
+touch /tmp/persistent/data
+ls /tmp/persistent/
+```
+```cat
 data  lost+found
+```
+return
+```bash
+exit
 ```
 
 It's time to destroy the pod and let the deployment launch a new pod. The expectation is that the PV is available again in the new pod and the data in `/tmp/persistent` is still present. Let's check that:
 
 ```bash
-$ kubectl delete po pv-deploy-69959dccb5-jhxxw
+kubectl delete po pv-deploy-69959dccb5-jhxxw
+```
+```cat
 pod pv-deploy-69959dccb5-jhxxw deleted
+```
 
-$ kubectl get po
+```bash
+kubectl get po
+```
+```cat
 NAME                         READY   STATUS    RESTARTS   AGE
 pv-deploy-69959dccb5-kwrrv   1/1     Running   0          16m
+```
 
-$ kubectl exec -it pv-deploy-69959dccb5-kwrrv -- bash
-bash-4.2$ ls /tmp/persistent/
+```bash
+kubectl exec -it pv-deploy-69959dccb5-kwrrv -- bash
+```
+```bash
+ls /tmp/persistent/
+```
+```cat
 data  lost+found
+```
+```bash
+exit
 ```
 
 And indeed, the `data` file and its content is still where it is expected to be.
@@ -63,7 +94,9 @@ And indeed, the `data` file and its content is still where it is expected to be.
 Note that the default behavior is that even when the deployment is deleted, the PVC (and the PV) continues to exist. This storage protection feature helps avoiding data loss. Once you're sure you don't need the data anymore, you can go ahead and delete the PVC and with it eventually destroy the PV:
 
 ```bash
-$ kubectl delete pvc myclaim
+kubectl delete pvc myclaim
+```
+```cat
 persistentvolumeclaim "myclaim" deleted
 ```
 

--- a/content/page/rcs.md
+++ b/content/page/rcs.md
@@ -14,17 +14,23 @@ Let's create an [RC](https://github.com/openshift-evangelists/kbe/blob/main/spec
 that supervises a single replica of a pod:
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/rcs/rc.yaml
+kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/rcs/rc.yaml
 ```
 
 You can see the RC and the pod it looks after like so:
 
 ```bash
-$ kubectl get rc
+kubectl get rc
+```
+```cat
 NAME                DESIRED   CURRENT   READY     AGE
 rcex                1         1         1         3m
+```
 
-$ kubectl get pods --show-labels
+```bash
+kubectl get pods --show-labels
+```
+```cat
 NAME           READY     STATUS    RESTARTS   AGE    LABELS
 rcex-qrv8j     1/1       Running   0          4m     app=sise
 ```
@@ -38,9 +44,12 @@ Note two things here:
 To scale up, that is, to increase the number of replicas, do:
 
 ```bash
-$ kubectl scale --replicas=3 rc/rcex
-
-$ kubectl get pods -l app=sise
+kubectl scale --replicas=3 rc/rcex
+```
+```bash
+kubectl get pods -l app=sise
+```
+```cat
 NAME         READY     STATUS    RESTARTS   AGE
 rcex-1rh9r   1/1       Running   0          54s
 rcex-lv6xv   1/1       Running   0          54s
@@ -51,7 +60,9 @@ rcex-qrv8j   1/1       Running   0          10m
 Finally, to get rid of the RC and the pods it is supervising, use:
 
 ```bash
-$ kubectl delete rc rcex
+kubectl delete rc rcex
+```
+```cat
 replicationcontroller "rcex" deleted
 ```
 

--- a/content/page/sd.md
+++ b/content/page/sd.md
@@ -14,9 +14,11 @@ Let's create a [service](https://github.com/openshift-evangelists/kbe/blob/main/
 some pods along with it:
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/sd/rc.yaml
+kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/sd/rc.yaml
+```
 
-$ kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/sd/svc.yaml
+```bash
+kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/sd/svc.yaml
 ```
 
 Now we want to connect to the `thesvc` service from within the cluster, say, from another service.
@@ -24,23 +26,32 @@ To simulate this, we create a [jump pod](https://github.com/openshift-evangelist
 in the same namespace (`default`, since we didn't specify anything else):
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/sd/jumpod.yaml
+kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/sd/jumpod.yaml
 ```
 
 The DNS add-on will make sure that our service `thesvc` is available via the FQDN
 `thesvc.default.svc.cluster.local` from other pods in the cluster. Let's try it out:
 
 ```bash
-$ kubectl exec -it jumpod -c shell -- ping thesvc.default.svc.cluster.local
+kubectl exec -it jumpod -c shell -- ping thesvc.default.svc.cluster.local
+```
+```cat
 PING thesvc.default.svc.cluster.local (172.30.251.137) 56(84) bytes of data.
 ...
+```
+
+Send a break signal to close the connection
+```bash
+^C
 ```
 
 The answer to the `ping` tells us that the service is available via the cluster
 IP `172.30.251.137`. We can directly connect to and consume the service (in the same namespace) like so:
 
- ```bash
- $ kubectl exec -it jumpod -c shell -- curl http://thesvc/info
+```bash
+kubectl exec -it jumpod -c shell -- curl http://thesvc/info
+```
+```cat
 {"host": "thesvc", "version": "0.5.0", "from": "172.17.0.5"}
 ```
 
@@ -59,18 +70,22 @@ Let's see how that works by creating:
 If you're not familiar with namespaces, check out the [namespace examples](/ns/) first.
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/sd/other-ns.yaml
-
-$ kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/sd/other-rc.yaml
-
-$ kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/sd/other-svc.yaml
+kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/sd/other-ns.yaml
+```
+```bash
+kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/sd/other-rc.yaml
+```
+```bash
+kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/sd/other-svc.yaml
 ```
 
 We're now in the position to consume the service `thesvc` in namespace `other` from the
 `default` namespace (again via the jump pod):
 
- ```bash
-$ kubectl exec -it jumpod -c shell -- curl http://thesvc.other/info
+```bash
+kubectl exec -it jumpod -c shell -- curl http://thesvc.other/info
+```
+```cat
 {"host": "thesvc.other", "version": "0.5.0", "from": "172.17.0.5"}
 ```
 
@@ -80,13 +95,16 @@ connect to services across the cluster.
 You can destroy all the resources created with:
 
 ```bash
-$ kubectl delete pods jumpod
-
-$ kubectl delete svc thesvc
-
-$ kubectl delete rc rcsise
-
-$ kubectl delete ns other
+kubectl delete pods jumpod
+```
+```bash
+kubectl delete svc thesvc
+```
+```bash
+kubectl delete rc rcsise
+```
+```bash
+kubectl delete ns other
 ```
 
 Keep in mind that removing a namespace will destroy every resource inside.

--- a/content/page/secrets.md
+++ b/content/page/secrets.md
@@ -18,12 +18,18 @@ to use such information in a safe and reliable way with the following properties
 Let's create a secret `apikey` that holds a (made-up) API key:
 
 ```bash
-$ echo -n "A19fh68B001j" > ./apikey.txt
-
-$ kubectl create secret generic apikey --from-file=./apikey.txt
+echo -n "A19fh68B001j" > ./apikey.txt
+```
+```bash
+kubectl create secret generic apikey --from-file=./apikey.txt
+```
+```cat
 secret "apikey" created
-
-$ kubectl describe secrets/apikey
+```
+```bash
+kubectl describe secrets/apikey
+```
+```cat
 Name:           apikey
 Namespace:      default
 Labels:         <none>
@@ -41,17 +47,29 @@ via a [volume](/volumes/):
 
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/secrets/pod.yaml
+kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/secrets/pod.yaml
 ```
 
 If we now exec into the container we see the secret mounted at `/tmp/apikey`:
 
+```bash
+kubectl exec -it consumesec -c shell -- bash
 ```
-$ kubectl exec -it consumesec -c shell -- bash
-[root@consumesec /]# mount | grep apikey
+```bash
+mount | grep apikey
+```
+```cat
 tmpfs on /tmp/apikey type tmpfs (ro,relatime)
-[root@consumesec /]# cat /tmp/apikey/apikey.txt
+```
+```bash
+cat /tmp/apikey/apikey.txt
+```
+```cat
 A19fh68B001j
+```
+return
+```bash
+exit
 ```
 
 Note that for service accounts Kubernetes automatically creates secrets containing
@@ -60,7 +78,7 @@ credentials for accessing the API and modifies your pods to use this type of sec
 You can remove both the pod and the secret with:
 
 ```bash
-$ kubectl delete pod/consumesec secret/apikey
+kubectl delete pod/consumesec secret/apikey
 ```
 
 [Previous](/volumes) | [Next](/logging)

--- a/content/page/services.md
+++ b/content/page/services.md
@@ -14,19 +14,25 @@ and a [service](https://github.com/openshift-evangelists/kbe/blob/main/specs/ser
 along with it:
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/services/rc.yaml
-
-$ kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/services/svc.yaml
+kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/services/rc.yaml
+```
+```bash
+kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/services/svc.yaml
 ```
 
 Now we have the supervised pod running:
 
 ```bash
-$ kubectl get pods -l app=sise
+kubectl get pods -l app=sise
+```
+```cat
 NAME           READY     STATUS    RESTARTS   AGE
 rcsise-6nq3k   1/1       Running   0          57s
-
-$ kubectl describe pod rcsise-6nq3k
+```
+```bash
+kubectl describe pod rcsise-6nq3k
+```
+```cat
 Name:                   rcsise-6nq3k
 Namespace:              default
 Security Policy:        restricted
@@ -44,19 +50,32 @@ You can, from within the cluster, access the pod directly via its
 assigned IP `172.17.0.3`:
 
 ```bash
-[cluster] $ curl 172.17.0.3:9876/info
+minikube ssh # oc `oc rsh`
+```
+```bash
+curl 172.17.0.3:9876/info
+```
+```cat
 {"host": "172.17.0.3:9876", "version": "0.5.0", "from": "172.17.0.1"}
+```
+```bash
+exit
 ```
 
 This is however, as mentioned above, not advisable since the IPs assigned
 to pods may change. Hence, enter the `simpleservice` we've created:
 
 ```bash
-$ kubectl get svc
+kubectl get svc
+```
+```cat
 NAME              CLUSTER-IP       EXTERNAL-IP   PORT(S)                   AGE
 simpleservice     172.30.228.255   <none>        80/TCP                    5m
-
-$ kubectl describe svc simpleservice
+```
+```bash
+kubectl describe svc simpleservice
+```
+```cat
 Name:                   simpleservice
 Namespace:              default
 Labels:                 <none>
@@ -75,7 +94,12 @@ in our case `app=sise`.
 From within the cluster we can now access `simpleservice` like so:
 
 ```bash
-[cluster] $ curl 172.30.228.255:80/info
+minikube ssh # or `oc rsh`
+```
+```bash
+curl 172.30.228.255:80/info
+```
+```cat
 {"host": "172.30.228.255", "version": "0.5.0", "from": "10.0.2.15"}
 ```
 
@@ -87,11 +111,18 @@ with a certain IP package.
 Looking at the rules that concern our service (executed on a cluster node) yields:
 
 ```bash
-[cluster] $ sudo iptables-save | grep simpleservice
+sudo iptables-save | grep simpleservice
+```
+```cat
 -A KUBE-SEP-4SQFZS32ZVMTQEZV -s 172.17.0.3/32 -m comment --comment "default/simpleservice:" -j KUBE-MARK-MASQ
 -A KUBE-SEP-4SQFZS32ZVMTQEZV -p tcp -m comment --comment "default/simpleservice:" -m tcp -j DNAT --to-destination 172.17.0.3:9876
 -A KUBE-SERVICES -d 172.30.228.255/32 -p tcp -m comment --comment "default/simpleservice: cluster IP" -m tcp --dport 80 -j KUBE-SVC-EZC6WLOVQADP4IAW
 -A KUBE-SVC-EZC6WLOVQADP4IAW -m comment --comment "default/simpleservice:" -j KUBE-SEP-4SQFZS32ZVMTQEZV
+```
+
+return to continue
+```bash
+exit
 ```
 
 Above you can see the four rules that `kube-proxy` has thankfully added to the
@@ -101,10 +132,16 @@ should be forwarded to `172.17.0.3:9876`, which is our pod.
 Let’s now add a second pod by scaling up the RC supervising it:
 
 ```bash
-$ kubectl scale --replicas=2 rc/rcsise
+kubectl scale --replicas=2 rc/rcsise
+```
+```cat
 replicationcontroller "rcsise" scaled
+```
 
-$ kubectl get pods -l app=sise
+```bash
+kubectl get pods -l app=sise
+```
+```cat
 NAME           READY     STATUS    RESTARTS   AGE
 rcsise-6nq3k   1/1       Running   0          15m
 rcsise-nv8zm   1/1       Running   0          5s
@@ -114,7 +151,12 @@ When we now check the relevant parts of the routing table again we notice
 the addition of a bunch of IPtables rules:
 
 ```bash
-[cluster] $ sudo iptables-save | grep simpleservice
+minikube ssh # or `oc rsh`
+```
+```bash
+sudo iptables-save | grep simpleservice
+```
+```cat
 -A KUBE-SEP-4SQFZS32ZVMTQEZV -s 172.17.0.3/32 -m comment --comment "default/simpleservice:" -j KUBE-MARK-MASQ
 -A KUBE-SEP-4SQFZS32ZVMTQEZV -p tcp -m comment --comment "default/simpleservice:" -m tcp -j DNAT --to-destination 172.17.0.3:9876
 -A KUBE-SEP-PXYYII6AHMUWKLYX -s 172.17.0.4/32 -m comment --comment "default/simpleservice:" -j KUBE-MARK-MASQ
@@ -127,8 +169,13 @@ the addition of a bunch of IPtables rules:
 In above routing table listing we see rules for the newly created pod serving at
 `172.17.0.4:9876` as well as an additional rule:
 
-```
+```cat
 -A KUBE-SVC-EZC6WLOVQADP4IAW -m comment --comment "default/simpleservice:" -m statistic --mode random --probability 0.50000000000 -j KUBE-SEP-4SQFZS32ZVMTQEZV
+```
+
+return to continue
+```bash
+exit
 ```
 
 This causes the traffic to the service being equally split between our two pods
@@ -137,9 +184,11 @@ by invoking the `statistics` module of IPtables.
 You can remove all the resources created by doing:
 
 ```bash
-$ kubectl delete svc simpleservice
+kubectl delete svc simpleservice
+```
 
-$ kubectl delete rc rcsise
+```bash
+kubectl delete rc rcsise
 ```
 
 [Previous](/deployments) | [Next](/sd)

--- a/content/page/statefulset.md
+++ b/content/page/statefulset.md
@@ -12,13 +12,15 @@ In order to see how this all plays together, we will be using an [educational Ku
 Let's start with creating the [stateful app](https://raw.githubusercontent.com/openshift-evangelists/mehdb/main/app.yaml), that is, the `StatefulSet` along with the persistent volumes and the headless service:
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/mehdb/main/app.yaml
+kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/mehdb/main/app.yaml
 ```
 
 After a minute or so, you can have a look at all the resources that have been created:
 
 ```bash
-$ kubectl get sts,po,pvc,svc
+kubectl get sts,po,pvc,svc
+```
+```cat
 NAME                     DESIRED   CURRENT   AGE
 statefulset.apps/mehdb   2         2         1m
 
@@ -37,8 +39,9 @@ service/mehdb   ClusterIP   None         <none>        9876/TCP   1m
 Now we can check if the stateful app is working properly. To do this, we use the `/status` endpoint of the headless service `mehdb:9876` and since we haven't put any data yet into the datastore, we'd expect that `0` keys are reported:
 
 ```bash
-$ kubectl run -it --rm jumpod --restart=Never --image=quay.io/openshiftlabs/jump:0.2 -- curl mehdb:9876/status?level=full
-If you don't see a command prompt, try pressing enter.
+kubectl run -it --rm jumpod --restart=Never --image=quay.io/openshiftlabs/jump:0.2 -- curl mehdb:9876/status?level=full
+```
+```cat
 0
 pod "jumpod" deleted
 ```

--- a/content/page/volumes.md
+++ b/content/page/volumes.md
@@ -20,9 +20,12 @@ Let's create a [pod](https://github.com/openshift-evangelists/kbe/blob/main/spec
 with two containers that use an `emptyDir` volume to exchange data:
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/volumes/pod.yaml
-
-$ kubectl describe pod sharevol
+kubectl apply -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/volumes/pod.yaml
+```
+```bash
+kubectl describe pod sharevol
+```
+```cat
 Name:                   sharevol
 Namespace:              default
 ...
@@ -36,10 +39,21 @@ We first exec into one of the containers in the pod, `c1`, check the volume moun
 and generate some data:
 
 ```bash
-$ kubectl exec -it sharevol -c c1 -- bash
-[root@sharevol /]# mount | grep xchange
+kubectl exec -it sharevol -c c1 -- bash
+```
+```bash
+mount | grep xchange
+```
+```cat
 /dev/vda3 on /tmp/xchange type xfs (rw,relatime,seclabel,attr2,inode64,rjquota)
-[root@sharevol /]# echo 'some data' > /tmp/xchange/data
+```
+```bash
+echo 'some data' > /tmp/xchange/data
+```
+
+return to continue
+```bash
+exit
 ```
 
 When we now exec into `c2`, the second container running in the pod, we can see
@@ -47,22 +61,40 @@ the volume mounted at `/tmp/data` and are able to read the data created in the
 previous step:
 
 ```bash
-$ kubectl exec -it sharevol -c c2 -- bash
-[root@sharevol /]# mount | grep /tmp/data
+kubectl exec -it sharevol -c c2 -- bash
+```
+```bash
+mount | grep /tmp/data
+```
+```cat
 /dev/vda3 on /tmp/data type xfs (rw,relatime,seclabel,attr2,inode64,prjquota)
-[root@sharevol /]# cat /tmp/data/data/
+```
+
+```bash
+cat /tmp/data/data/
+```
+```cat
 cat: /tmp/data/data/: Not a directory
-[root@sharevol /]# cat /tmp/data/data
+```
+```bash
+cat /tmp/data/data
+```
+```cat
 some data
 ```
 
 Note that in each container you need to decide where to mount the volume and
 that for `emptyDir` you currently can not specify resource consumption limits.
 
+return to continue
+```bash
+exit
+```
+
 You can remove the pod with:
 
 ```bash
-$ kubectl delete pod/sharevol
+kubectl delete pod/sharevol
 ```
 
 As already described, this will destroy the shared volume and all its contents.

--- a/themes/beautifulhugo/static/css/main.css
+++ b/themes/beautifulhugo/static/css/main.css
@@ -1,3 +1,6 @@
+.highlight pre {
+  margin-bottom: 0px; margin-top:10px;
+}
 @import url("pygment_highlights.css");
 
 /* --- General --- */


### PR DESCRIPTION
This PR will:

1. Update code examples so that copy and paste will be easier in the future (removing command prompts from examples)
2. Separate example commands from the example output responses
3. Display the expected command output directly below each example