### PR TITLE
Add cleanup steps for the last chapters.

### DIFF
--- a/content/page/ic.md
+++ b/content/page/ic.md
@@ -5,7 +5,7 @@ date = "2019-02-26"
 url = "/ic/"
 +++
 
-It's sometimes necessary to prepare a container running in a pod. For example, you might want to wait for a service being available, want to configure things at runtime, or init some data in a database. In all of these cases, [init containers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) are useful. Note that Kubernetes will execute all init containers (and they must all exit successfully) before the main container(s) are executed. 
+It's sometimes necessary to prepare a container running in a pod. For example, you might want to wait for a service being available, want to configure things at runtime, or init some data in a database. In all of these cases, [init containers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) are useful. Note that Kubernetes will execute all init containers (and they must all exit successfully) before the main container(s) are executed.
 
 So let's create an [deployment](https://github.com/openshift-evangelists/kbe/blob/main/specs/ic/deploy.yaml) consisting of an init container that writes a message into a file at `/ic/this` and the main (long-running) container reading out this file, then:
 
@@ -39,6 +39,12 @@ INIT_DONE
 Send a break signal (Ctrl-C) when you're ready to disconnect from the log stream:
 ```bash
 ^C
+```
+
+Now we can cleanup after we are done as follows:
+
+```bash
+kubectl delete -f https://raw.githubusercontent.com/openshift-evangelists/kbe/main/specs/ic/deploy.yaml
 ```
 
 If you want to learn more about init containers and related topics, check out the blog post [Kubernetes: A Pod’s Life](https://blog.openshift.com/kubernetes-pods-life/).

--- a/content/page/statefulset.md
+++ b/content/page/statefulset.md
@@ -7,7 +7,7 @@ url = "/statefulset/"
 
 If you have a stateless app you want to use a deployment. However, for a stateful app you might want to use a [StatefulSet](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/). Unlike a deployment, the `StatefulSet` provides certain guarantees about the identity of the pods it is managing (that is, predictable names) and about the startup order. Two more things that are different compared to a deployment: for network communication you need to create a [headless services](https://kubernetes.io/docs/concepts/services-networking/service/#headless-services) and for persistency the `StatefulSet` manages a [persistent volume](/pv) per pod.
 
-In order to see how this all plays together, we will be using an [educational Kubernetes-native NoSQL datastore](https://blog.openshift.com/kubernetes-statefulset-in-action/). 
+In order to see how this all plays together, we will be using an [educational Kubernetes-native NoSQL datastore](https://blog.openshift.com/kubernetes-statefulset-in-action/).
 
 Let's start with creating the [stateful app](https://raw.githubusercontent.com/openshift-evangelists/mehdb/main/app.yaml), that is, the `StatefulSet` along with the persistent volumes and the headless service:
 
@@ -49,5 +49,12 @@ pod "jumpod" deleted
 And indeed we see `0` keys being available, reported above.
 
 Note that sometimes a `StatefulSet` is not the best fit for your stateful app. You might be better off defining a [custom resource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) along with writing a custom controller to have finer-grained control over your workload.
+
+We can now cleanup after we are done using:
+
+```bash
+kubectl delete -f https://raw.githubusercontent.com/openshift-evangelists/mehdb/main/app.yaml
+kubectl delete pvc/data-mehdb-0
+```
 
 [Previous](/jobs) | [Next](/ic)


### PR DESCRIPTION
As discussed in #66, this PR adds some cleanup steps in the following chapters: 

- stateful sets
- init containers. 

I just deleted the yaml spec that was used to create the example, and additionally in the stateful sets chapter, I deleted the pic claim separately. 

cc: @ryanj 